### PR TITLE
`leakMessage` のイベントが発火したあとに必ず reaction を消すようにした

### DIFF
--- a/src/actions/leakMessage.spec.ts
+++ b/src/actions/leakMessage.spec.ts
@@ -32,7 +32,7 @@ describe('🚓 leakMessage', () => {
   });
 
   describe('🆗 RESOLVE ALL', () => {
-    it('👮 twitter への投稿まですべて通った場合は twitter のURLを送信する', async () => {
+    it('👮 twitter への投稿まですべて通った場合は twitter のURLを送信する, リアクションも消す', async () => {
       const twitterRepository = new TwitterRepository(mockTwitterTokens);
       const twitterService = new TwitterService(twitterRepository);
 
@@ -57,11 +57,12 @@ describe('🚓 leakMessage', () => {
       const replyOptions = buildNoMentionReply(`:watching_you2: ${tweetURL}`);
 
       expect(reactionMock.message.reply).toHaveBeenCalledWith(replyOptions);
+      expect(reactionMock.remove).toHaveBeenCalled();
     });
   });
 
   describe('🆖 REJECTED', () => {
-    it('👮 ContentsTooLongException が帰ってきたらその問題を通知', async () => {
+    it('👮 ContentsTooLongException が帰ってきたらその問題を通知, リアクションも消す', async () => {
       const twitterRepository = new TwitterRepository(mockTwitterTokens);
       const twitterService = new TwitterService(twitterRepository);
 

--- a/src/actions/leakMessage.ts
+++ b/src/actions/leakMessage.ts
@@ -97,5 +97,8 @@ export const leakMessage = async (
       await reaction.message.channel.send(errorMessage);
       return;
     }
+  } finally {
+    // ついた絵文字が消される
+    await reaction.remove();
   }
 };

--- a/src/lib/mocks/messageReaction.ts
+++ b/src/lib/mocks/messageReaction.ts
@@ -61,5 +61,6 @@ export const generateMockMessageReaction = (
         cache: mockGuildEmojis(options?.emoji?.omitExpectEmoji || false),
       },
     },
+    remove: jest.fn(),
   } as unknown as MessageReaction;
 };


### PR DESCRIPTION
# Referenced issue

<!-- 関連Issueがあれば -->

- close #39

# やったこと

<!-- このPRで実施した事項を並べる -->

- 表題の通り

# その他

<!-- 注意事項など -->

- **reaction を消す実装を入れたのでメッセージの管理権限を要求するようになりました**
  - 現状以下の権限で足りることを確認している
  
![スクリーンショット 2022-03-20 041925](https://user-images.githubusercontent.com/40014236/159135444-b15f7417-0294-4013-9e7b-acfd49efac22.png)

# チェック項目

- [x] ちゃんとテストを書きましたか？
- [x] linter の警告はありませんか？
- [x] `yarn lint:fix` でコードフォーマットを修正しましたか？
