### PR TITLE
ツイートの削除機能を実装

### DIFF
--- a/src/actions/removeTweet.spec.ts
+++ b/src/actions/removeTweet.spec.ts
@@ -16,7 +16,7 @@ describe('🚓 removeTweet', () => {
         name: 'general',
       },
       emoji: {
-        name: 'x',
+        name: '❌',
       },
     };
 
@@ -38,7 +38,7 @@ describe('🚓 removeTweet', () => {
           content: 'https://twitter.com/hogeUser/status/12345678901234568901',
         },
         emoji: {
-          name: 'x',
+          name: '❌',
         },
       });
       const reactionUserMock = generateMockUser({ id: 'mockUser' });
@@ -65,7 +65,7 @@ describe('🚓 removeTweet', () => {
           content: 'https://hoge.com/hogeUser/12345678901234568901',
         },
         emoji: {
-          name: 'x',
+          name: '❌',
         },
       });
       const reactionUserMock = generateMockUser({ id: 'mockUser' });

--- a/src/actions/removeTweet.spec.ts
+++ b/src/actions/removeTweet.spec.ts
@@ -34,6 +34,9 @@ describe('🚓 removeTweet', () => {
 
       const reactionMock = generateMockMessageReaction({
         message: {
+          author: {
+            bot: true,
+          },
           referenceUserId: 'mockUser',
           content: 'https://twitter.com/hogeUser/status/12345678901234568901',
         },
@@ -61,6 +64,9 @@ describe('🚓 removeTweet', () => {
 
       const reactionMock = generateMockMessageReaction({
         message: {
+          author: {
+            bot: true,
+          },
           referenceUserId: 'mockUser',
           content: 'https://hoge.com/hogeUser/12345678901234568901',
         },

--- a/src/actions/removeTweet.spec.ts
+++ b/src/actions/removeTweet.spec.ts
@@ -1,0 +1,88 @@
+import { removeTweet } from '@/actions/removeTweet';
+import {
+  generateMockMessageReaction,
+  GenerateMockMessageReactionOptions,
+} from '@/lib/mocks/messageReaction';
+import { generateMockUser } from '@/lib/mocks/user';
+import { TwitterRepository } from '@/lib/repositories/twitter';
+import { mockTwitterTokens } from '@/lib/mocks/env';
+import { TwitterService } from '@/lib/services/twitter';
+import { buildNoMentionReply } from '@/actions/utils/buildNoMentionReply';
+
+describe('🚓 removeTweet', () => {
+  it('👮 フィルターを通らない場合は void で早期リターンする', () => {
+    const mockReactionOptions: GenerateMockMessageReactionOptions = {
+      channel: {
+        name: 'general',
+      },
+      emoji: {
+        name: 'x',
+      },
+    };
+
+    const reactionMock = generateMockMessageReaction(mockReactionOptions);
+    removeTweet(reactionMock, generateMockUser());
+    expect(reactionMock.message.reply).not.toHaveBeenCalled();
+  });
+
+  describe('🆗 RESOLVED', () => {
+    it('👮 すべて正常終了した場合は指定のメッセージで reply する', async () => {
+      const twitterRepository = new TwitterRepository(mockTwitterTokens);
+      const twitterService = new TwitterService(twitterRepository);
+
+      twitterService.deleteTweet = () => Promise.resolve(true);
+
+      const reactionMock = generateMockMessageReaction({
+        message: {
+          referenceUserId: 'mockUser',
+          content: 'https://twitter.com/hogeUser/status/12345678901234568901',
+        },
+        emoji: {
+          name: 'x',
+        },
+      });
+      const reactionUserMock = generateMockUser({ id: 'mockUser' });
+
+      await removeTweet(reactionMock, reactionUserMock, {
+        twitter: twitterService,
+      });
+      expect(reactionMock.message.reply).toHaveBeenCalledWith(
+        'ツイート削除したで. 念の為リンク踏んで確認してな'
+      );
+    });
+  });
+
+  describe('🆖 REJECTED', () => {
+    it('👮 tweetId の取得に失敗したときに Error のテキストが投下される', async () => {
+      const twitterRepository = new TwitterRepository(mockTwitterTokens);
+      const twitterService = new TwitterService(twitterRepository);
+
+      twitterService.deleteTweet = () => Promise.resolve(true);
+
+      const reactionMock = generateMockMessageReaction({
+        message: {
+          referenceUserId: 'mockUser',
+          content: 'https://hoge.com/hogeUser/12345678901234568901',
+        },
+        emoji: {
+          name: 'x',
+        },
+      });
+      const reactionUserMock = generateMockUser({ id: 'mockUser' });
+
+      await removeTweet(reactionMock, reactionUserMock, {
+        twitter: twitterService,
+      });
+
+      const replyOption = buildNoMentionReply(
+        `${reactionMock.emoji} < なんか知らんエラーが出たわ`
+      );
+      expect(reactionMock.message.reply).toHaveBeenCalledWith(replyOption);
+
+      const errorMessage = 'Throw unexpected URL!';
+      const text = '```\n' + `${errorMessage}\n` + '```';
+
+      expect(reactionMock.message.channel.send).toHaveBeenCalledWith(text);
+    });
+  });
+});

--- a/src/actions/removeTweet.ts
+++ b/src/actions/removeTweet.ts
@@ -31,8 +31,9 @@ export const removeTweet = async (
     channelName: channel.name,
     isReactedMessageAuthorBot: reaction.message.author?.bot || false,
     reactorId: reactorUser.id,
-    referencedMessageAuthorId: (await reaction.message.fetchReference()).author
-      .id,
+    referencedMessageAuthorId: reaction.message.reference
+      ? (await reaction.message.fetchReference()).author.id
+      : '',
   };
 
   if (!shouldRemoveTweet(filter)) return;
@@ -71,13 +72,13 @@ export const removeTweet = async (
       return;
     }
 
-    if (error instanceof Error) {
-      await reaction.message.reply(
-        buildNoMentionReply(`${reaction.emoji} < なんか知らんエラーが出たわ`)
-      );
-      const errorMessage = '```\n' + `${error.message}\n` + '```';
-      await reaction.message.channel.send(errorMessage);
-      return;
-    }
+    // if (error instanceof Error) {
+    //   await reaction.message.reply(
+    //     buildNoMentionReply(`${reaction.emoji} < なんか知らんエラーが出たわ`)
+    //   );
+    //   const errorMessage = '```\n' + `${error.message}\n` + '```';
+    //   await reaction.message.channel.send(errorMessage);
+    //   return;
+    // }
   }
 };

--- a/src/actions/removeTweet.ts
+++ b/src/actions/removeTweet.ts
@@ -8,6 +8,10 @@ import {
   ServerErrorException,
   UnauthorizedException,
 } from '@/lib/exceptions';
+import {
+  getChannelFromReaction,
+  isTextChannel,
+} from '@/typeGuards/isTextChannel';
 
 interface Services {
   twitter: TwitterService;
@@ -18,8 +22,13 @@ export const removeTweet = async (
   reactorUser: User,
   services?: Services
 ) => {
+  // 原則として来ることはないがコンパイラを黙らせる意味で書いている
+  const channel = getChannelFromReaction(reaction);
+  if (!isTextChannel(channel)) return;
+
   const filter: Parameters<typeof shouldRemoveTweet>[0] = {
     emojiName: reaction.emoji.name || '',
+    channelName: channel.name,
     isReactedMessageAuthorBot: reaction.message.author?.bot || false,
     reactorId: reactorUser.id,
     referencedMessageAuthorId: (await reaction.message.fetchReference()).author

--- a/src/actions/removeTweet.ts
+++ b/src/actions/removeTweet.ts
@@ -31,7 +31,11 @@ export const removeTweet = async (
 
   try {
     const tweetId = pickTweetId(reaction.message.content || '');
-    return twitterService.deleteTweet(tweetId);
+    await twitterService.deleteTweet(tweetId);
+
+    await reaction.message.reply(
+      'ツイート削除したで. 念の為リンク踏んで確認してな'
+    );
   } catch (error: unknown) {
     if (error instanceof NetworkHandshakeException) {
       await reaction.message.reply(

--- a/src/actions/removeTweet.ts
+++ b/src/actions/removeTweet.ts
@@ -1,0 +1,23 @@
+import { MessageReaction, User } from 'discord.js';
+import { TwitterService } from '@/lib/services/twitter';
+import { shouldRemoveTweet } from '@/actions/utils/removeTweet/shouldRemoveTweet';
+
+interface Services {
+  twitter: TwitterService;
+}
+
+export const removeTweet = async (
+  reaction: MessageReaction,
+  reactorUser: User,
+  services?: Services
+) => {
+  const filter: Parameters<typeof shouldRemoveTweet>[0] = {
+    emojiName: reaction.emoji.name || '',
+    isReactedMessageAuthorBot: reaction.message.author?.bot || false,
+    reactorId: reactorUser.id,
+    referencedMessageAuthorId: (await reaction.message.fetchReference()).author
+      .id,
+  };
+
+  if(!shouldRemoveTweet(filter)) return;
+};

--- a/src/actions/removeTweet.ts
+++ b/src/actions/removeTweet.ts
@@ -72,13 +72,13 @@ export const removeTweet = async (
       return;
     }
 
-    // if (error instanceof Error) {
-    //   await reaction.message.reply(
-    //     buildNoMentionReply(`${reaction.emoji} < なんか知らんエラーが出たわ`)
-    //   );
-    //   const errorMessage = '```\n' + `${error.message}\n` + '```';
-    //   await reaction.message.channel.send(errorMessage);
-    //   return;
-    // }
+    if (error instanceof Error) {
+      await reaction.message.reply(
+        buildNoMentionReply(`${reaction.emoji} < なんか知らんエラーが出たわ`)
+      );
+      const errorMessage = '```\n' + `${error.message}\n` + '```';
+      await reaction.message.channel.send(errorMessage);
+      return;
+    }
   }
 };

--- a/src/actions/utils/removeTweet/pickTweetId.spec.ts
+++ b/src/actions/utils/removeTweet/pickTweetId.spec.ts
@@ -1,0 +1,24 @@
+import { pickTweetId } from '@/actions/utils/removeTweet/pickTweetId';
+
+describe('🚓 pickTweetId', () => {
+  it('👮 正常例の場合は Id を返却', () => {
+    const tweetURL = 'https://twitter.com/hogeUser/status/12345678901';
+    const expectId = '12345678901';
+    expect(pickTweetId(tweetURL)).toBe(expectId);
+  });
+
+  it('👮 URL が twitter の形式と違う場合はエラーを返却', () => {
+    const tweetURL = 'https://hoge.com/fuga/piyo';
+    expect(() => pickTweetId(tweetURL)).toThrowError(Error);
+  });
+
+  it('👮 URL の statusId の中に変な文字が混ざっていた場合はエラーを返却', () => {
+    const tweetURL = 'https://twitter.com/hogeUser/status/fuga1234567890';
+    expect(() => pickTweetId(tweetURL)).toThrowError(Error);
+  });
+
+  it('👮 URL の末尾に変な文字が混ざっていた場合はエラーを返却', () => {
+    const tweetURL = 'https://twitter.com/hogeUser/status/1234678901?s=1';
+    expect(() => pickTweetId(tweetURL)).toThrowError(Error);
+  });
+});

--- a/src/actions/utils/removeTweet/pickTweetId.ts
+++ b/src/actions/utils/removeTweet/pickTweetId.ts
@@ -1,0 +1,17 @@
+/**
+ * twitter の URL から statusId のみ切り出して返す
+ * @param tweetURL e.g. `https://twitter.com/hogeUser/status/123456`
+ * @return e.g. `123456`
+ */
+export const pickTweetId = (tweetURL: string): string => {
+  const splitURL = tweetURL.split('/status/');
+  if (splitURL.length <= 1) throw Error('Throw unexpected URL!');
+  const statusId = splitURL[1];
+
+  // 行頭, 行末などにへんな string があれば例外を投げる
+  const identifierNumberRegEx = /^[0-9]*$/;
+  if (!identifierNumberRegEx.test(statusId))
+    throw Error('Throw unexpected URL!');
+
+  return statusId;
+};

--- a/src/actions/utils/removeTweet/shouldRemoveTweet.ts
+++ b/src/actions/utils/removeTweet/shouldRemoveTweet.ts
@@ -15,7 +15,7 @@ interface TweetRemoveRuleBases {
  */
 export const shouldRemoveTweet = (rules: TweetRemoveRuleBases): boolean => {
   // bot の発言についたものでなければ無視
-  if (rules.isReactedMessageAuthorBot) return false;
+  if (!rules.isReactedMessageAuthorBot) return false;
 
   // emoji.name が `❌` でなければ無視
   if (rules.emojiName !== '❌') return false;

--- a/src/actions/utils/removeTweet/shouldRemoveTweet.ts
+++ b/src/actions/utils/removeTweet/shouldRemoveTweet.ts
@@ -15,7 +15,7 @@ interface TweetRemoveRuleBases {
  */
 export const shouldRemoveTweet = (rules: TweetRemoveRuleBases): boolean => {
   // bot の発言についたものでなければ無視
-  if (!rules.isReactedMessageAuthorBot) return false;
+  if (rules.isReactedMessageAuthorBot) return false;
 
   // emoji.name が `x` でなければ無視
   if (rules.emojiName !== 'x') return false;

--- a/src/actions/utils/removeTweet/shouldRemoveTweet.ts
+++ b/src/actions/utils/removeTweet/shouldRemoveTweet.ts
@@ -17,8 +17,8 @@ export const shouldRemoveTweet = (rules: TweetRemoveRuleBases): boolean => {
   // bot の発言についたものでなければ無視
   if (rules.isReactedMessageAuthorBot) return false;
 
-  // emoji.name が `x` でなければ無視
-  if (rules.emojiName !== 'x') return false;
+  // emoji.name が `❌` でなければ無視
+  if (rules.emojiName !== '❌') return false;
 
   // チャンネル名がごみばこ以外の場所での発言は無視
   if (rules.channelName !== 'ごみばこ') return false;

--- a/src/actions/utils/removeTweet/shouldRemoveTweet.ts
+++ b/src/actions/utils/removeTweet/shouldRemoveTweet.ts
@@ -1,5 +1,6 @@
 interface TweetRemoveRuleBases {
   emojiName: string; // ついた emoji の名前
+  channelName: string; //チャンネル名
   isReactedMessageAuthorBot: boolean; // emoji がついたメッセージが bot の発言かどうか
   reactorId: string; // リアクションの emoji を追加した人
   referencedMessageAuthorId: string; //リファレンス元の作者
@@ -18,6 +19,9 @@ export const shouldRemoveTweet = (rules: TweetRemoveRuleBases): boolean => {
 
   // emoji.name が `x` でなければ無視
   if (rules.emojiName !== 'x') return false;
+
+  // チャンネル名がごみばこ以外の場所での発言は無視
+  if (rules.channelName !== 'ごみばこ') return false;
 
   // 最後に reference 元のユーザーと emoji の追加者が同じ id かどうかを返却
   return rules.reactorId === rules.referencedMessageAuthorId;

--- a/src/actions/utils/removeTweet/shouldRemoveTweet.ts
+++ b/src/actions/utils/removeTweet/shouldRemoveTweet.ts
@@ -1,0 +1,24 @@
+interface TweetRemoveRuleBases {
+  emojiName: string; // ついた emoji の名前
+  isReactedMessageAuthorBot: boolean; // emoji がついたメッセージが bot の発言かどうか
+  reactorId: string; // リアクションの emoji を追加した人
+  referencedMessageAuthorId: string; //リファレンス元の作者
+}
+
+/**
+ * ツイートを消去する Permission があるかどうかを検査
+ * - reference 元の筆者
+ * - Admins(TODO: 一旦要件から除外)
+ * - botMaintainer(TODO: 一旦要件から除外)
+ * この3者は削除可能とする
+ */
+export const shouldRemoveTweet = (rules: TweetRemoveRuleBases): boolean => {
+  // bot の発言についたものでなければ無視
+  if (!rules.isReactedMessageAuthorBot) return false;
+
+  // emoji.name が `x` でなければ無視
+  if (rules.emojiName !== 'x') return false;
+
+  // 最後に reference 元のユーザーと emoji の追加者が同じ id かどうかを返却
+  return rules.reactorId === rules.referencedMessageAuthorId;
+};

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,6 @@
-import { Client, MessageReaction } from 'discord.js';
+import { Client, MessageReaction, User } from 'discord.js';
 import { leakMessage } from '@/actions/leakMessage';
+import { removeTweet } from '@/actions/removeTweet';
 
 /**
  * イベントを登録していくための空間
@@ -11,9 +12,12 @@ export const subscribeEvents = (client: Client): Client => {
     console.log('start discord bot service!');
   });
 
-  client.on('messageReactionAdd', (reaction) => {
+  client.on('messageReactionAdd', (reaction, user) => {
     if (!(reaction instanceof MessageReaction)) return;
     leakMessage(reaction);
+
+    if (!(user instanceof User)) return;
+    removeTweet(reaction, user);
   });
 
   return client;

--- a/src/lib/mocks/messageReaction.ts
+++ b/src/lib/mocks/messageReaction.ts
@@ -22,6 +22,10 @@ const mockGuildEmojis = (omitExpectEmoji: boolean): GuildEmoji[] => {
 interface MockMessageReactionOptions {
   message: {
     content?: string;
+    referenceUserId?: string;
+    author?: {
+      bot?: boolean;
+    };
   };
   channel: {
     name?: string;
@@ -42,6 +46,9 @@ export const generateMockMessageReaction = (
   return {
     message: {
       content: options?.message?.content || 'mockMessage!',
+      author: {
+        bot: options?.message?.author || false,
+      },
       attachments: new Collection(),
       channel: {
         type: options?.channel?.type || 'GUILD_TEXT',
@@ -49,6 +56,12 @@ export const generateMockMessageReaction = (
         send: jest.fn().mockImplementation(),
       },
       reply: jest.fn().mockImplementation(),
+
+      // リプ元の参照
+      fetchReference: () =>
+        Promise.resolve({
+          author: { id: options?.message?.referenceUserId || 'hogeUser' },
+        }),
     },
     emoji: {
       name: options?.emoji?.name || 'thinking_mikan',

--- a/src/lib/mocks/messageReaction.ts
+++ b/src/lib/mocks/messageReaction.ts
@@ -58,6 +58,7 @@ export const generateMockMessageReaction = (
       reply: jest.fn().mockImplementation(),
 
       // リプ元の参照
+      reference: [],
       fetchReference: () =>
         Promise.resolve({
           author: { id: options?.message?.referenceUserId || 'hogeUser' },

--- a/src/lib/mocks/user.ts
+++ b/src/lib/mocks/user.ts
@@ -1,0 +1,11 @@
+import { User } from 'discord.js';
+
+interface MockUserOption {
+  id: string;
+}
+
+export const generateMockUser = (options?: MockUserOption): User => {
+  return {
+    id: options?.id || 'hogeUser',
+  } as unknown as User;
+};

--- a/src/lib/repositories/twitter.ts
+++ b/src/lib/repositories/twitter.ts
@@ -34,4 +34,13 @@ export class TwitterRepository {
   async uploadMedia(file: TUploadableMedia) {
     return this.client.v1.uploadMedia(file);
   }
+
+  /**
+   * tweet を削除する
+   * @param tweetId ツイートのId 123456789012345 みたいな数値形式になってる
+   * @return {Promise}
+   */
+  async deleteTweet(tweetId: string) {
+    return this.client.v1.deleteTweet(tweetId);
+  }
 }

--- a/src/lib/services/twitter.ts
+++ b/src/lib/services/twitter.ts
@@ -81,4 +81,28 @@ export class TwitterService {
       throw error;
     }
   }
+
+  async deleteTweet(tweetId: string): Promise<boolean> {
+    try {
+      return await this.repository
+        .deleteTweet(tweetId)
+        .then((res) => Boolean(res));
+    } catch (error: unknown) {
+      // シンプルに疎通ができなかったなどのエラー
+      if (error instanceof ApiRequestError) {
+        throw new NetworkHandshakeException();
+      }
+
+      // twitter から エラーのレスポンスが返却されたなどのエラー
+      if (error instanceof ApiResponseError) {
+        switch (error.code) {
+          case 401:
+            throw new UnauthorizedException();
+          case 500:
+            throw new ServerErrorException();
+        }
+      }
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
# Referenced issue

<!-- 関連Issueがあれば -->

- close #40

# やったこと

<!-- このPRで実施した事項を並べる -->

- ツイート削除機能実装
  - tweet のURLを共有したメッセージに対して `:x:` の絵文字を**筆者が**つけることで削除させることが可能です
  - 本人以外がつけても無視されます
  - 今後 Admin 権限持ちの人がつけた場合も削除するようにしたいが今後の課題としている
![スクリーンショット 2022-04-14 034247](https://user-images.githubusercontent.com/40014236/163248646-64fd38e3-437e-48b4-93b9-60f1ffc97e5c.png)

# その他

<!-- 注意事項など -->

# チェック項目

- [x] ちゃんとテストを書きましたか？
- [x] linter の警告はありませんか？
- [x] `yarn lint:fix` でコードフォーマットを修正しましたか？

